### PR TITLE
Start Evolving

### DIFF
--- a/src/test/executionSession.test.js
+++ b/src/test/executionSession.test.js
@@ -65,7 +65,7 @@ class StubWorkspace {
 
 test("ExecutionSession completes a valid action loop", async () => {
   const planner = new SequenceModel([
-    '{"action":"write_file","path":"src/feature.js","content":"export const feature = true;"}',
+    '{"action":"write_file","path":"src/feature.ts","content":"export const feature = true;"}',
     '{"action":"run_validation"}',
     '{"action":"finish","summary":"implemented feature","rationale":"added feature","prTitle":"Add feature"}'
   ]);
@@ -81,10 +81,10 @@ test("ExecutionSession completes a valid action loop", async () => {
 
 test("ExecutionSession retries within the same session after validation failure", async () => {
   const planner = new SequenceModel([
-    '{"action":"write_file","path":"src/feature.js","content":"broken"}',
+    '{"action":"write_file","path":"src/feature.ts","content":"broken"}',
     '{"action":"run_validation"}',
     '{"action":"finish","summary":"done"}',
-    '{"action":"write_file","path":"src/feature.js","content":"fixed"}',
+    '{"action":"write_file","path":"src/feature.ts","content":"fixed"}',
     '{"action":"run_validation"}',
     '{"action":"finish","summary":"done","rationale":"after fixing validation"}'
   ]);


### PR DESCRIPTION
Completed Issue #5 by evolving ExecutionSession test fixtures toward TypeScript-only alignment: updated test write_file action paths from .js to .ts in src/test/executionSession.test.js while preserving behavior.

Rationale: Intent: enforce master prompt policy consistency in generated/modified product-facing action examples. Trade-off: kept runtime JS code unchanged to avoid broad refactor risk in this iteration; focused on low-risk, high-signal test evolution. Evidence: validation passed (pnpm test: 26/26, pnpm check passed). Next step: incrementally migrate remaining JS-oriented examples and workspace/test assumptions toward a true TS code path.

Validation

```text

$ pnpm test
> evolvo@0.2.0 test /home/paddy/Evolvo
> node --test src/test/**/*.test.js

TAP version 13
# [dry-run] would restart process after merge
# [dry-run] would restart process after merge
# [dry-run] would restart process after merge
# Subtest: Evolver opens, reviews, and merges a PR after executing an issue
ok 1 - Evolver opens, reviews, and merges a PR after executing an issue
  ---
  duration_ms: 4.265481
  type: 'test'
  ...
# Subtest: Evolver can choose a non-first issue based on autonomous evaluation
ok 2 - Evolver can choose a non-first issue based on autonomous evaluation
  ---
  duration_ms: 1.876013
  type: 'test'
  ...
# Subtest: Evolver runs another fix cycle when self-review requests changes
ok 3 - Evolver runs another fix cycle when self-review requests changes
  ---
  duration_ms: 4.513905
  type: 'test'
  ...
# Subtest: Evolver labels the issue when validation never reaches a passing finish
ok 4 - Evolver labels the issue when validation never reaches a passing finish
  ---
  duration_ms: 2.741222
  type: 'test'
  ...
# Subtest: ExecutionSession completes a valid action loop
ok 5 - ExecutionSession completes a valid action loop
  ---
  duration_ms: 1.734263
  type: 'test'
  ...
# Subtest: ExecutionSession retries within the same session after validation failure
ok 6 - ExecutionSession retries within the same session after validation failure
  ---
  duration_ms: 1.406793
  type: 'test'
  ...
# Subtest: ExecutionSession fails after repeated malformed JSON responses
ok 7 - ExecutionSession fails after repeated malformed JSON responses
  ---
  duration_ms: 0.634791
  type: 'test'
  ...
# Subtest: FallbackProvider uses fallback when primary fails
ok 8 - FallbackProvider uses fallback when primary fails
  ---
  duration_ms: 1.526771
  type: 'test'
  ...
# Subtest: ensurePromptIssue creates first prompt issue when no issues exist
ok 9 - ensurePromptIssue creates first prompt issue when no issues exist
  ---
  duration_ms: 0.851784
  type: 'test'
  ...
# Subtest: GitHubClient can create and update dry-run pull requests linked to an issue marker
ok 10 - GitHubClient can create and update dry-run pull requests linked to an issue marker
  ---
  duration_ms: 1.083182
  type: 'test'
  ...
# Subtest: GitHubClient supports label removal and issue title lookup in dry-run mode
ok 11 - GitHubClient supports label removal and issue title lookup in dry-run mode
  ---
  duration_ms: 2.353709
  type: 'test'
  ...
# Subtest: GitHubClient dry-run merge and close update local state
ok 12 - GitHubClient dry-run merge and close update local state
  ---
  duration_ms: 0.293083
  type: 'test'
  ...
# Subtest: ConsoleLogger formats child scopes and redacts sensitive fields
ok 13 - ConsoleLogger formats child scopes and redacts sensitive fields
  ---
  duration_ms: 1.60115
  type: 'test'
  ...
# Subtest: MASTER_PROMPT encodes TypeScript-only and perseverance policy
ok 14 - MASTER_PROMPT encodes TypeScript-only and perseverance policy
  ---
  duration_ms: 11.34239
  type: 'test'
  ...
# Subtest: composePrompt wraps task under master prompt
ok 15 - composePrompt wraps task under master prompt
  ---
  duration_ms: 0.266705
  type: 'test'
  ...
# Subtest: extractOutputText reads structured Responses API content when output_text is absent
ok 16 - extractOutputText reads structured Responses API content when output_text is absent
  ---
  duration_ms: 0.842269
  type: 'test'
  ...
# Subtest: OpenAiProvider returns text from structured Responses API output
ok 17 - OpenAiProvider returns text from structured Responses API output
  ---
  duration_ms: 0.531781
  type: 'test'
  ...
# Subtest: PerformanceTracker records and returns latest snapshot
ok 18 - PerformanceTracker records and returns latest snapshot
  ---
  duration_ms: 1.54852
  type: 'test'
  ...
# Subtest: createAgentProviders uses Ollama as primary by default and OpenAI as fallback
ok 19 - createAgentProviders uses Ollama as primary by default and OpenAI as fallback
  ---
  duration_ms: 2.612861
  type: 'test'
  ...
# Subtest: createAgentProviders can use OpenAI as primary and Ollama as fallback
ok 20 - createAgentProviders can use OpenAI as primary and Ollama as fallback
  ---
  duration_ms: 0.222809
  type: 'test'
  ...
# Subtest: createAgentProviders requires OPENAI_API_KEY when OpenAI is primary
ok 21 - createAgentProviders requires OPENAI_API_KEY when OpenAI is primary
  ---
  duration_ms: 0.498246
  type: 'test'
  ...
# To /tmp/evolvo-remote-Tq6ju8
#  * [new branch]      main -> main
# To /tmp/evolvo-remote-8AovYq
#  * [new branch]      main -> main
# To /tmp/evolvo-remote-6Qdb00
#  * [new branch]      main -> main
# Subtest: branchNameForIssue creates a deterministic branch slug
ok 22 - branchNameForIssue creates a deterministic branch slug
  ---
  duration_ms: 4.810568
  type: 'test'
  ...
# Subtest: buildAuthenticatedGitArgs injects a per-command auth header
ok 23 - buildAuthenticatedGitArgs injects a per-command auth header
  ---
  duration_ms: 0.773256
  type: 'test'
  ...
# Subtest: Workspace prepareBranch allows .env and .evolvo but blocks other dirty files
ok 24 - Workspace prepareBranch allows .env and .evolvo but blocks other dirty files
  ---
  duration_ms: 75.747994
  type: 'test'
  ...
# Subtest: Workspace prepareBranch checks out a deterministic issue branch
ok 25 - Workspace prepareBranch checks out a deterministic issue branch
  ---
  duration_ms: 88.203372
  type: 'test'
  ...
# Subtest: Workspace stages only touched files
ok 26 - Workspace stages only touched files
  ---
  duration_ms: 62.197536
  type: 'test'
  ...
1..26
# tests 26
# suites 0
# pass 26
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 350.435858

$ pnpm check
> evolvo@0.2.0 check /home/paddy/Evolvo
> node --check src/index.js

```
Closes #5