### PR TITLE
test: enforce structured rationale logging in evolver issue events

### DIFF
--- a/src/test/evolver.test.js
+++ b/src/test/evolver.test.js
@@ -337,3 +337,35 @@ test("Evolver labels the issue when validation never reaches a passing finish", 
   assert.equal(github.merged.length, 0);
   assert.ok(github.labels.some((entry) => entry.labels.includes("needs-human-intervention")));
 });
+
+test("Evolver logs rationale in structured intent/trade-offs/evidence/next-step format", async () => {
+  const workspace = new StubWorkspace();
+  const { evolver, github } = createEvolver({
+    plannerResponses: [
+      '{"action":"work","issueNumber":11}',
+      '{"action":"write_file","path":"src/feature.js","content":"export const feature = true;"}',
+      '{"action":"run_validation"}',
+      '{"action":"finish","summary":"implemented","rationale":"Intent: add baseline feature | Trade-offs: minimal scope | Evidence: validation ok | Next step: monitor"}'
+    ],
+    reviewerResponses: [
+      '{"decision":"approve","body":"looks good","rationale":"Intent: verify quality gate | Trade-offs: lightweight review | Evidence: tests passing | Next step: merge"}'
+    ],
+    workspace
+  });
+
+  await evolver.run();
+
+  const issueLog = github.comments.find((entry) => /🧾 Attempt result: implemented/.test(entry.message));
+  assert.ok(issueLog);
+  assert.match(issueLog.message, /Intent:/);
+  assert.match(issueLog.message, /Trade-offs:/);
+  assert.match(issueLog.message, /Evidence:/);
+  assert.match(issueLog.message, /Next step:/);
+
+  const reviewLog = github.comments.find((entry) => /🔍 Review round 1\/2: approve/.test(entry.message));
+  assert.ok(reviewLog);
+  assert.match(reviewLog.message, /Intent:/);
+  assert.match(reviewLog.message, /Trade-offs:/);
+  assert.match(reviewLog.message, /Evidence:/);
+  assert.match(reviewLog.message, /Next step:/);
+});


### PR DESCRIPTION
## Summary
- Added a focused evolver test to enforce structured rationale content in issue event logs.
- Verifies `Intent`, `Trade-offs`, `Evidence`, and `Next step` appear in:
  - attempt-result issue comment logs
  - review-round issue comment logs

## Why
This locks in the richer rationale policy as a regression guard and supports evolutionary traceability.

## Validation
- `pnpm test` ✅ (30 passing)
- `pnpm check` ✅

Validation

```text

$ pnpm test
> evolvo@0.2.0 test /home/paddy/Evolvo
> node --test src/test/**/*.test.js

TAP version 13
# [dry-run] would restart process after merge
# [dry-run] would restart process after merge
# [dry-run] would restart process after merge
# Subtest: Evolver opens, reviews, and merges a PR after executing an issue
ok 1 - Evolver opens, reviews, and merges a PR after executing an issue
  ---
  duration_ms: 5.487464
  type: 'test'
  ...
# Subtest: Evolver can choose a non-first issue based on autonomous evaluation
ok 2 - Evolver can choose a non-first issue based on autonomous evaluation
  ---
  duration_ms: 0.815595
  type: 'test'
  ...
# Subtest: Evolver runs another fix cycle when self-review requests changes
ok 3 - Evolver runs another fix cycle when self-review requests changes
  ---
  duration_ms: 2.326955
  type: 'test'
  ...
# [dry-run] would restart process after merge
# Subtest: Evolver labels the issue when a review follow-up produces no new diff
ok 4 - Evolver labels the issue when a review follow-up produces no new diff
  ---
  duration_ms: 4.735495
  type: 'test'
  ...
# Subtest: Evolver labels the issue when validation never reaches a passing finish
ok 5 - Evolver labels the issue when validation never reaches a passing finish
  ---
  duration_ms: 0.423391
  type: 'test'
  ...
# Subtest: Evolver logs rationale in structured intent/trade-offs/evidence/next-step format
ok 6 - Evolver logs rationale in structured intent/trade-offs/evidence/next-step format
  ---
  duration_ms: 0.430882
  type: 'test'
  ...
# Subtest: ExecutionSession completes a valid action loop
ok 7 - ExecutionSession completes a valid action loop
  ---
  duration_ms: 3.754145
  type: 'test'
  ...
# Subtest: ExecutionSession retries within the same session after validation failure
ok 8 - ExecutionSession retries within the same session after validation failure
  ---
  duration_ms: 1.874672
  type: 'test'
  ...
# Subtest: ExecutionSession fails after repeated malformed JSON responses
ok 9 - ExecutionSession fails after repeated malformed JSON responses
  ---
  duration_ms: 0.44012
  type: 'test'
  ...
# Subtest: FallbackProvider uses fallback when primary fails
ok 10 - FallbackProvider uses fallback when primary fails
  ---
  duration_ms: 1.985481
  type: 'test'
  ...
# Subtest: ensurePromptIssue creates first prompt issue when no issues exist
ok 11 - ensurePromptIssue creates first prompt issue when no issues exist
  ---
  duration_ms: 1.41864
  type: 'test'
  ...
# Subtest: GitHubClient can create and update dry-run pull requests linked to an issue marker
ok 12 - GitHubClient can create and update dry-run pull requests linked to an issue marker
  ---
  duration_ms: 0.378718
  type: 'test'
  ...
# Subtest: GitHubClient supports label removal and issue title lookup in dry-run mode
ok 13 - GitHubClient supports label removal and issue title lookup in dry-run mode
  ---
  duration_ms: 2.384919
  type: 'test'
  ...
# Subtest: GitHubClient dry-run merge and close update local state
ok 14 - GitHubClient dry-run merge and close update local state
  ---
  duration_ms: 1.238387
  type: 'test'
  ...
# Subtest: GitHubClient supports pull request comments in dry-run mode
ok 15 - GitHubClient supports pull request comments in dry-run mode
  ---
  duration_ms: 0.428169
  type: 'test'
  ...
# Subtest: ConsoleLogger formats child scopes and redacts sensitive fields
ok 16 - ConsoleLogger formats child scopes and redacts sensitive fields
  ---
  duration_ms: 1.546522
  type: 'test'
  ...
# Subtest: MASTER_PROMPT encodes TypeScript-only and perseverance policy
ok 17 - MASTER_PROMPT encodes TypeScript-only and perseverance policy
  ---
  duration_ms: 0.750339
  type: 'test'
  ...
# Subtest: composePrompt wraps task under master prompt
ok 18 - composePrompt wraps task under master prompt
  ---
  duration_ms: 0.189915
  type: 'test'
  ...
# Subtest: extractOutputText reads structured Responses API content when output_text is absent
ok 19 - extractOutputText reads structured Responses API content when output_text is absent
  ---
  duration_ms: 0.574255
  type: 'test'
  ...
# Subtest: OpenAiProvider returns text from structured Responses API output
ok 20 - OpenAiProvider returns text from structured Responses API output
  ---
  duration_ms: 0.311087
  type: 'test'
  ...
# Subtest: PerformanceTracker records and returns latest snapshot
ok 21 - PerformanceTracker records and returns latest snapshot
  ---
  duration_ms: 13.951839
  type: 'test'
  ...
# Subtest: createAgentProviders uses Ollama as primary by default and OpenAI as fallback
ok 22 - createAgentProviders uses Ollama as primary by default and OpenAI as fallback
  ---
  duration_ms: 2.720571
  type: 'test'
  ...
# Subtest: createAgentProviders can use OpenAI as primary and Ollama as fallback
ok 23 - createAgentProviders can use OpenAI as primary and Ollama as fallback
  ---
  duration_ms: 0.155616
  type: 'test'
  ...
# Subtest: createAgentProviders requires OPENAI_API_KEY when OpenAI is primary
ok 24 - createAgentProviders requires OPENAI_API_KEY when OpenAI is primary
  ---
  duration_ms: 0.303957
  type: 'test'
  ...
# To /tmp/evolvo-remote-v9Cx8a
#  * [new branch]      main -> main
# To /tmp/evolvo-remote-zib5cr
#  * [new branch]      main -> main
# To /tmp/evolvo-remote-rlu900
#  * [new branch]      main -> main
# To /tmp/evolvo-remote-RW1yQm
#  * [new branch]      main -> main
# Subtest: branchNameForIssue creates a deterministic branch slug
ok 25 - branchNameForIssue creates a deterministic branch slug
  ---
  duration_ms: 1.692612
  type: 'test'
  ...
# Subtest: buildAuthenticatedGitArgs injects a per-command auth header
ok 26 - buildAuthenticatedGitArgs injects a per-command auth header
  ---
  duration_ms: 0.643051
  type: 'test'
  ...
# Subtest: Workspace prepareBranch allows .env and .evolvo but blocks other dirty files
ok 27 - Workspace prepareBranch allows .env and .evolvo but blocks other dirty files
  ---
  duration_ms: 170.933168
  type: 'test'
  ...
# Subtest: Workspace prepareBranch checks out a deterministic issue branch
ok 28 - Workspace prepareBranch checks out a deterministic issue branch
  ---
  duration_ms: 131.739376
  type: 'test'
  ...
# Subtest: Workspace stages only touched files
ok 29 - Workspace stages only touched files
  ---
  duration_ms: 120.287866
  type: 'test'
  ...
# Subtest: Workspace clears touched files after a successful publish
ok 30 - Workspace clears touched files after a successful publish
  ---
  duration_ms: 154.522174
  type: 'test'
  ...
1..30
# tests 30
# suites 0
# pass 30
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 712.869397

$ pnpm check
> evolvo@0.2.0 check /home/paddy/Evolvo
> node --check src/index.js

```
Closes #19