### PR TITLE
docs: define Issue #21 next meaningful outcome for Evolvo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 Evolvo runs one command (`pnpm start`) and operates as a GitHub-native engineering loop that can branch locally, edit files, validate changes, open/update PRs, self-review, and auto-merge.
 
+## Current instruction thread (Issue #21)
+
+**Next meaningful development outcome:**
+
+Build and merge a production-ready TypeScript migration baseline by converting core `.js` source modules to `.ts`, keeping behavior unchanged, and ensuring tests and build validation pass.
+
+### Acceptance criteria
+
+- Migrate an initial vertical slice of runtime code from JavaScript to TypeScript (at minimum: prompt composition, provider selection boundary, and one orchestration entry path).
+- Keep existing autonomous loop behavior functionally equivalent (no fabricated outcomes; no regression in issue/PR flow logic).
+- Add or update tests to cover migrated TypeScript modules and preserve current behavioral assertions.
+- Ensure the validation gate passes (`tests pass` and `build/typecheck passes`) before merge.
+- Open/update PR with rationale quality including: **Intent, Trade-offs, Evidence, Next step**.
+
+### Why this is the right next step
+
+- The master policy already requires TypeScript-only implementation for modified/generated product code.
+- A focused migration baseline unlocks safer future self-evolution by introducing stronger static guarantees where orchestration decisions are made.
+- This outcome is measurable and benchmark-friendly for future challenge issues.
+
 ## Default model policy
 
 - Evolvo runs with a persistent master instruction contract to keep behavior consistent across decisions.


### PR DESCRIPTION
## Summary
- Added a dedicated **Current instruction thread (Issue #21)** section to README.
- Defined the next meaningful outcome as a **production-ready TypeScript migration baseline**.
- Added explicit acceptance criteria, including:
  - vertical-slice migration targets,
  - behavior preservation,
  - test updates,
  - passing validation gates,
  - structured rationale format.

## Why
Issue #21 asks to describe the next meaningful development outcome for Evolvo. This change turns that prompt into a concrete, measurable execution target.

Closes #21

Validation

```text

$ pnpm test
> evolvo@0.2.0 test /home/paddy/Evolvo
> node --test src/test/**/*.test.js

TAP version 13
# [dry-run] would restart process after merge
# [dry-run] would restart process after merge
# [dry-run] would restart process after merge
# Subtest: Evolver opens, reviews, and merges a PR after executing an issue
ok 1 - Evolver opens, reviews, and merges a PR after executing an issue
  ---
  duration_ms: 6.173187
  type: 'test'
  ...
# Subtest: Evolver can choose a non-first issue based on autonomous evaluation
ok 2 - Evolver can choose a non-first issue based on autonomous evaluation
  ---
  duration_ms: 0.445687
  type: 'test'
  ...
# Subtest: Evolver runs another fix cycle when self-review requests changes
ok 3 - Evolver runs another fix cycle when self-review requests changes
  ---
  duration_ms: 1.408351
  type: 'test'
  ...
# [dry-run] would restart process after merge
# Subtest: Evolver labels the issue when a review follow-up produces no new diff
ok 4 - Evolver labels the issue when a review follow-up produces no new diff
  ---
  duration_ms: 3.369094
  type: 'test'
  ...
# Subtest: Evolver labels the issue when validation never reaches a passing finish
ok 5 - Evolver labels the issue when validation never reaches a passing finish
  ---
  duration_ms: 0.551494
  type: 'test'
  ...
# Subtest: Evolver logs rationale in structured intent/trade-offs/evidence/next-step format
ok 6 - Evolver logs rationale in structured intent/trade-offs/evidence/next-step format
  ---
  duration_ms: 0.771886
  type: 'test'
  ...
# Subtest: ExecutionSession completes a valid action loop
ok 7 - ExecutionSession completes a valid action loop
  ---
  duration_ms: 1.122158
  type: 'test'
  ...
# Subtest: ExecutionSession retries within the same session after validation failure
ok 8 - ExecutionSession retries within the same session after validation failure
  ---
  duration_ms: 4.106033
  type: 'test'
  ...
# Subtest: ExecutionSession fails after repeated malformed JSON responses
ok 9 - ExecutionSession fails after repeated malformed JSON responses
  ---
  duration_ms: 1.172219
  type: 'test'
  ...
# Subtest: FallbackProvider does not escalate before threshold
ok 10 - FallbackProvider does not escalate before threshold
  ---
  duration_ms: 2.086286
  type: 'test'
  ...
# Subtest: FallbackProvider escalates to fallback after threshold
ok 11 - FallbackProvider escalates to fallback after threshold
  ---
  duration_ms: 0.519816
  type: 'test'
  ...
# Subtest: FallbackProvider tracks timeout threshold for escalation
ok 12 - FallbackProvider tracks timeout threshold for escalation
  ---
  duration_ms: 0.416966
  type: 'test'
  ...
# Subtest: FallbackProvider resets stuck counters after successful primary completion
ok 13 - FallbackProvider resets stuck counters after successful primary completion
  ---
  duration_ms: 0.306222
  type: 'test'
  ...
# Subtest: ensurePromptIssue creates first prompt issue when no issues exist
ok 14 - ensurePromptIssue creates first prompt issue when no issues exist
  ---
  duration_ms: 0.633113
  type: 'test'
  ...
# Subtest: GitHubClient can create and update dry-run pull requests linked to an issue marker
ok 15 - GitHubClient can create and update dry-run pull requests linked to an issue marker
  ---
  duration_ms: 0.267614
  type: 'test'
  ...
# Subtest: GitHubClient supports label removal and issue title lookup in dry-run mode
ok 16 - GitHubClient supports label removal and issue title lookup in dry-run mode
  ---
  duration_ms: 1.317546
  type: 'test'
  ...
# Subtest: GitHubClient dry-run merge and close update local state
ok 17 - GitHubClient dry-run merge and close update local state
  ---
  duration_ms: 0.209854
  type: 'test'
  ...
# Subtest: GitHubClient supports pull request comments in dry-run mode
ok 18 - GitHubClient supports pull request comments in dry-run mode
  ---
  duration_ms: 0.142118
  type: 'test'
  ...
# Subtest: restartProcess spawns a detached replacement process
ok 19 - restartProcess spawns a detached replacement process
  ---
  duration_ms: 1.079734
  type: 'test'
  ...
# Subtest: main relaunches the process when a live run requests restart
ok 20 - main relaunches the process when a live run requests restart
  ---
  duration_ms: 0.321262
  type: 'test'
  ...
# Subtest: main skips relaunching when dry-run mode requests restart
ok 21 - main skips relaunching when dry-run mode requests restart
  ---
  duration_ms: 0.220302
  type: 'test'
  ...
# Subtest: ConsoleLogger formats child scopes and redacts sensitive fields
ok 22 - ConsoleLogger formats child scopes and redacts sensitive fields
  ---
  duration_ms: 2.751708
  type: 'test'
  ...
# Subtest: MASTER_PROMPT encodes TypeScript-only and perseverance policy
ok 23 - MASTER_PROMPT encodes TypeScript-only and perseverance policy
  ---
  duration_ms: 0.51113
  type: 'test'
  ...
# Subtest: composePrompt wraps task under master prompt
ok 24 - composePrompt wraps task under master prompt
  ---
  duration_ms: 0.102582
  type: 'test'
  ...
# Subtest: extractOutputText reads structured Responses API content when output_text is absent
ok 25 - extractOutputText reads structured Responses API content when output_text is absent
  ---
  duration_ms: 0.773721
  type: 'test'
  ...
# Subtest: OpenAiProvider returns text from structured Responses API output
ok 26 - OpenAiProvider returns text from structured Responses API output
  ---
  duration_ms: 0.479177
  type: 'test'
  ...
# Subtest: PerformanceTracker records and returns latest snapshot
ok 27 - PerformanceTracker records and returns latest snapshot
  ---
  duration_ms: 2.798603
  type: 'test'
  ...
# Subtest: createAgentProviders uses Ollama as primary by default and OpenAI as fallback
ok 28 - createAgentProviders uses Ollama as primary by default and OpenAI as fallback
  ---
  duration_ms: 1.319594
  type: 'test'
  ...
# Subtest: createAgentProviders can use OpenAI as primary and Ollama as fallback
ok 29 - createAgentProviders can use OpenAI as primary and Ollama as fallback
  ---
  duration_ms: 0.42719
  type: 'test'
  ...
# Subtest: createAgentProviders requires OPENAI_API_KEY when OpenAI is primary
ok 30 - createAgentProviders requires OPENAI_API_KEY when OpenAI is primary
  ---
  duration_ms: 0.517098
  type: 'test'
  ...
# To /tmp/evolvo-remote-ZF0zhH
#  * [new branch]      main -> main
# To /tmp/evolvo-remote-uBG7Vp
#  * [new branch]      main -> main
# To /tmp/evolvo-remote-r7F8NS
#  * [new branch]      main -> main
# To /tmp/evolvo-remote-DcsEnq
#  * [new branch]      main -> main
# Subtest: branchNameForIssue creates a deterministic branch slug
ok 31 - branchNameForIssue creates a deterministic branch slug
  ---
  duration_ms: 1.515741
  type: 'test'
  ...
# Subtest: buildAuthenticatedGitArgs injects a per-command auth header
ok 32 - buildAuthenticatedGitArgs injects a per-command auth header
  ---
  duration_ms: 0.677762
  type: 'test'
  ...
# Subtest: Workspace prepareBranch allows .env and .evolvo but blocks other dirty files
ok 33 - Workspace prepareBranch allows .env and .evolvo but blocks other dirty files
  ---
  duration_ms: 123.394336
  type: 'test'
  ...
# Subtest: Workspace prepareBranch checks out a deterministic issue branch
ok 34 - Workspace prepareBranch checks out a deterministic issue branch
  ---
  duration_ms: 74.267196
  type: 'test'
  ...
# Subtest: Workspace stages only touched files
ok 35 - Workspace stages only touched files
  ---
  duration_ms: 55.574647
  type: 'test'
  ...
# Subtest: Workspace clears touched files after a successful publish
ok 36 - Workspace clears touched files after a successful publish
  ---
  duration_ms: 88.557696
  type: 'test'
  ...
1..36
# tests 36
# suites 0
# pass 36
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 438.190038

$ pnpm check
> evolvo@0.2.0 check /home/paddy/Evolvo
> node --check src/index.js

```