### PR TITLE
Self-Evolution: Strengthen local-LLM resilience with adaptive Ollama retry/fallback orchestration

### DIFF
--- a/src/providers/ollama.js
+++ b/src/providers/ollama.js
@@ -42,6 +42,28 @@ function classifyError(error) {
   return "other";
 }
 
+function isRetryableErrorCategory(category) {
+  return category === "timeout" || category === "network";
+}
+
+function createTimeoutSignal(timeoutMs) {
+  if (typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function") {
+    return { signal: AbortSignal.timeout(timeoutMs), cleanup() {} };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort(new Error(`Timeout after ${timeoutMs}ms`));
+  }, timeoutMs);
+
+  return {
+    signal: controller.signal,
+    cleanup() {
+      clearTimeout(timer);
+    }
+  };
+}
+
 export class OllamaProvider {
   constructor(baseUrl, model = "qwen-coder-3:30b", logger = createNoopLogger(), options = {}) {
     this.baseUrl = baseUrl;
@@ -60,11 +82,12 @@ export class OllamaProvider {
   async probeHealth() {
     const startedAt = this.now();
     const timeout = this.retryPolicy.warmupTimeoutMs;
+    const { signal, cleanup } = createTimeoutSignal(timeout);
 
     try {
       const response = await this.fetchImpl(`${this.baseUrl}/api/tags`, {
         method: "GET",
-        signal: AbortSignal.timeout(timeout)
+        signal
       });
 
       const healthy = response.ok;
@@ -99,6 +122,8 @@ export class OllamaProvider {
         error
       });
       throw error;
+    } finally {
+      cleanup();
     }
   }
 
@@ -187,8 +212,16 @@ export class OllamaProvider {
         });
         return output;
       } catch (error) {
+        const alreadyCapturedHttpError = error instanceof Error && /Ollama request failed: status=\d+/.test(error.message);
+        if (alreadyCapturedHttpError) {
+          if (error && typeof error === "object") {
+            error.attemptTelemetry = telemetry;
+          }
+          throw error;
+        }
+
         const category = classifyError(error);
-        const retryable = attempt < attempts;
+        const retryable = attempt < attempts && isRetryableErrorCategory(category);
         telemetry.push({
           attempt,
           ok: false,

--- a/src/test/ollama.test.js
+++ b/src/test/ollama.test.js
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { OllamaProvider } from "../providers/ollama.js";
+import { createNoopLogger } from "../logger.js";
+
+test("OllamaProvider records one telemetry entry for a single non-retryable HTTP failure", async () => {
+  const provider = new OllamaProvider("http://localhost:11434", "test-model", createNoopLogger(), {
+    retryPolicy: {
+      warmupEnabled: false,
+      maxAttempts: 3,
+      retryOnStatuses: [503]
+    },
+    fetchImpl: async () => ({
+      ok: false,
+      status: 400,
+      async text() {
+        return "bad request";
+      }
+    })
+  });
+
+  await assert.rejects(async () => {
+    await provider.complete("hello");
+  }, (error) => {
+    assert.equal(Array.isArray(error.attemptTelemetry), true);
+    assert.equal(error.attemptTelemetry.length, 1);
+    assert.equal(error.attemptTelemetry[0].status, 400);
+    return true;
+  });
+});
+
+test("OllamaProvider does not retry non-retryable thrown errors", async () => {
+  let calls = 0;
+  const provider = new OllamaProvider("http://localhost:11434", "test-model", createNoopLogger(), {
+    retryPolicy: {
+      warmupEnabled: false,
+      maxAttempts: 3
+    },
+    fetchImpl: async () => {
+      calls += 1;
+      throw new Error("schema invalid response shape");
+    }
+  });
+
+  await assert.rejects(() => provider.complete("hello"));
+  assert.equal(calls, 1);
+});
+
+test("OllamaProvider retries retryable HTTP status and succeeds", async () => {
+  let calls = 0;
+  const provider = new OllamaProvider("http://localhost:11434", "test-model", createNoopLogger(), {
+    retryPolicy: {
+      warmupEnabled: false,
+      maxAttempts: 3,
+      baseDelayMs: 0,
+      maxDelayMs: 0,
+      jitterRatio: 0,
+      retryOnStatuses: [503]
+    },
+    sleepImpl: async () => {},
+    fetchImpl: async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          ok: false,
+          status: 503,
+          async text() {
+            return "temporary unavailable";
+          }
+        };
+      }
+
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return { response: "ok" };
+        }
+      };
+    }
+  });
+
+  const output = await provider.complete("hello");
+  assert.equal(output, "ok");
+  assert.equal(calls, 2);
+});
+
+test("OllamaProvider warmup probe timeout path sets unhealthy lastHealth", async () => {
+  const provider = new OllamaProvider("http://localhost:11434", "test-model", createNoopLogger(), {
+    retryPolicy: {
+      warmupEnabled: true,
+      warmupTimeoutMs: 5
+    },
+    fetchImpl: async (_url, options) => new Promise((resolve, reject) => {
+      if (options?.signal) {
+        options.signal.addEventListener("abort", () => {
+          reject(options.signal.reason ?? new Error("aborted"));
+        });
+      }
+      setTimeout(() => {
+        resolve({ ok: true, status: 200, json: async () => ({ response: "late" }) });
+      }, 50);
+    })
+  });
+
+  await assert.rejects(() => provider.complete("hello"));
+  assert.equal(provider.lastHealth?.healthy, false);
+});


### PR DESCRIPTION
Implemented the hardening pass for Issue #29 in Ollama resilience orchestration. Updated `src/providers/ollama.js` to prevent duplicate telemetry for HTTP non-OK failures, tightened retryability for thrown errors to only network/timeout categories, and added a portability-safe timeout signal helper with fallback when `AbortSignal.timeout` is unavailable. Added focused tests in `src/test/ollama.test.js` covering single-entry telemetry on non-retryable HTTP failures, immediate stop on non-retryable thrown errors, retry/success on retryable HTTP 503, and warmup probe timeout health behavior. Validation is passing (`pnpm test`, `pnpm check`).

Rationale: Intent: Address review-requested reliability/correctness gaps in local Ollama retry orchestration before merge, specifically telemetry correctness, retry safety, and timeout portability. | Trade-offs: Added modest complexity (timeout helper + categorized retry logic + HTTP-error guard) to reduce false telemetry inflation and avoid wasteful retries on deterministic errors; kept behavior conservative by defaulting unknown thrown errors to non-retryable. | Evidence: Code changes in `src/providers/ollama.js` introduce `createTimeoutSignal`, `isRetryableErrorCategory`, and `alreadyCapturedHttpError` handling to avoid duplicate attempt records; tests in `src/test/ollama.test.js` assert all requested scenarios; full validation passed with 40/40 tests and `pnpm check` success. | Next step: Merge this PR, then extend fallback-chain orchestration and escalation evidence logging at provider-selection/session layers to complete broader Issue #29 resilience objectives.

Validation

```text

$ pnpm test
> evolvo@0.2.0 test /home/paddy/Evolvo
> node --test src/test/**/*.test.js

TAP version 13
# [dry-run] would restart process after merge
# [dry-run] would restart process after merge
# [dry-run] would restart process after merge
# Subtest: Evolver opens, reviews, and merges a PR after executing an issue
ok 1 - Evolver opens, reviews, and merges a PR after executing an issue
  ---
  duration_ms: 3.341526
  type: 'test'
  ...
# Subtest: Evolver can choose a non-first issue based on autonomous evaluation
ok 2 - Evolver can choose a non-first issue based on autonomous evaluation
  ---
  duration_ms: 0.500313
  type: 'test'
  ...
# Subtest: Evolver runs another fix cycle when self-review requests changes
ok 3 - Evolver runs another fix cycle when self-review requests changes
  ---
  duration_ms: 2.133616
  type: 'test'
  ...
# [dry-run] would restart process after merge
# Subtest: Evolver labels the issue when a review follow-up produces no new diff
ok 4 - Evolver labels the issue when a review follow-up produces no new diff
  ---
  duration_ms: 3.611398
  type: 'test'
  ...
# Subtest: Evolver labels the issue when validation never reaches a passing finish
ok 5 - Evolver labels the issue when validation never reaches a passing finish
  ---
  duration_ms: 0.717504
  type: 'test'
  ...
# Subtest: Evolver logs rationale in structured intent/trade-offs/evidence/next-step format
ok 6 - Evolver logs rationale in structured intent/trade-offs/evidence/next-step format
  ---
  duration_ms: 1.255062
  type: 'test'
  ...
# Subtest: ExecutionSession completes a valid action loop
ok 7 - ExecutionSession completes a valid action loop
  ---
  duration_ms: 2.050221
  type: 'test'
  ...
# Subtest: ExecutionSession retries within the same session after validation failure
ok 8 - ExecutionSession retries within the same session after validation failure
  ---
  duration_ms: 4.204479
  type: 'test'
  ...
# Subtest: ExecutionSession fails after repeated malformed JSON responses
ok 9 - ExecutionSession fails after repeated malformed JSON responses
  ---
  duration_ms: 0.485435
  type: 'test'
  ...
# Subtest: FallbackProvider does not escalate before threshold
ok 10 - FallbackProvider does not escalate before threshold
  ---
  duration_ms: 3.659931
  type: 'test'
  ...
# Subtest: FallbackProvider escalates to fallback after threshold
ok 11 - FallbackProvider escalates to fallback after threshold
  ---
  duration_ms: 0.647237
  type: 'test'
  ...
# Subtest: FallbackProvider tracks timeout threshold for escalation
ok 12 - FallbackProvider tracks timeout threshold for escalation
  ---
  duration_ms: 0.461876
  type: 'test'
  ...
# Subtest: FallbackProvider resets stuck counters after successful primary completion
ok 13 - FallbackProvider resets stuck counters after successful primary completion
  ---
  duration_ms: 0.342571
  type: 'test'
  ...
# Subtest: ensurePromptIssue creates first prompt issue when no issues exist
ok 14 - ensurePromptIssue creates first prompt issue when no issues exist
  ---
  duration_ms: 2.871833
  type: 'test'
  ...
# Subtest: GitHubClient can create and update dry-run pull requests linked to an issue marker
ok 15 - GitHubClient can create and update dry-run pull requests linked to an issue marker
  ---
  duration_ms: 0.571264
  type: 'test'
  ...
# Subtest: GitHubClient supports label removal and issue title lookup in dry-run mode
ok 16 - GitHubClient supports label removal and issue title lookup in dry-run mode
  ---
  duration_ms: 2.03003
  type: 'test'
  ...
# Subtest: GitHubClient dry-run merge and close update local state
ok 17 - GitHubClient dry-run merge and close update local state
  ---
  duration_ms: 0.384748
  type: 'test'
  ...
# Subtest: GitHubClient supports pull request comments in dry-run mode
ok 18 - GitHubClient supports pull request comments in dry-run mode
  ---
  duration_ms: 0.338241
  type: 'test'
  ...
# Subtest: restartProcess spawns a detached replacement process
ok 19 - restartProcess spawns a detached replacement process
  ---
  duration_ms: 1.621586
  type: 'test'
  ...
# Subtest: main relaunches the process when a live run requests restart
ok 20 - main relaunches the process when a live run requests restart
  ---
  duration_ms: 0.715904
  type: 'test'
  ...
# Subtest: main skips relaunching when dry-run mode requests restart
ok 21 - main skips relaunching when dry-run mode requests restart
  ---
  duration_ms: 0.401272
  type: 'test'
  ...
# Subtest: ConsoleLogger formats child scopes and redacts sensitive fields
ok 22 - ConsoleLogger formats child scopes and redacts sensitive fields
  ---
  duration_ms: 1.524358
  type: 'test'
  ...
# Subtest: MASTER_PROMPT encodes TypeScript-only and perseverance policy
ok 23 - MASTER_PROMPT encodes TypeScript-only and perseverance policy
  ---
  duration_ms: 0.556987
  type: 'test'
  ...
# Subtest: composePrompt wraps task under master prompt
ok 24 - composePrompt wraps task under master prompt
  ---
  duration_ms: 0.1167
  type: 'test'
  ...
# Subtest: OllamaProvider records one telemetry entry for a single non-retryable HTTP failure
ok 25 - OllamaProvider records one telemetry entry for a single non-retryable HTTP failure
  ---
  duration_ms: 1.580721
  type: 'test'
  ...
# Subtest: OllamaProvider does not retry non-retryable thrown errors
ok 26 - OllamaProvider does not retry non-retryable thrown errors
  ---
  duration_ms: 0.454568
  type: 'test'
  ...
# Subtest: OllamaProvider retries retryable HTTP status and succeeds
ok 27 - OllamaProvider retries retryable HTTP status and succeeds
  ---
  duration_ms: 1.263998
  type: 'test'
  ...
# Subtest: OllamaProvider warmup probe timeout path sets unhealthy lastHealth
ok 28 - OllamaProvider warmup probe timeout path sets unhealthy lastHealth
  ---
  duration_ms: 5.583257
  type: 'test'
  ...
# Subtest: extractOutputText reads structured Responses API content when output_text is absent
ok 29 - extractOutputText reads structured Responses API content when output_text is absent
  ---
  duration_ms: 0.563691
  type: 'test'
  ...
# Subtest: OpenAiProvider returns text from structured Responses API output
ok 30 - OpenAiProvider returns text from structured Responses API output
  ---
  duration_ms: 0.262166
  type: 'test'
  ...
# Subtest: PerformanceTracker records and returns latest snapshot
ok 31 - PerformanceTracker records and returns latest snapshot
  ---
  duration_ms: 2.523159
  type: 'test'
  ...
# Subtest: createAgentProviders uses Ollama as primary by default and OpenAI as fallback
ok 32 - createAgentProviders uses Ollama as primary by default and OpenAI as fallback
  ---
  duration_ms: 1.424889
  type: 'test'
  ...
# Subtest: createAgentProviders can use OpenAI as primary and Ollama as fallback
ok 33 - createAgentProviders can use OpenAI as primary and Ollama as fallback
  ---
  duration_ms: 0.136483
  type: 'test'
  ...
# Subtest: createAgentProviders requires OPENAI_API_KEY when OpenAI is primary
ok 34 - createAgentProviders requires OPENAI_API_KEY when OpenAI is primary
  ---
  duration_ms: 0.36381
  type: 'test'
  ...
# To /tmp/evolvo-remote-aOqS7A
#  * [new branch]      main -> main
# To /tmp/evolvo-remote-2XjUay
#  * [new branch]      main -> main
# To /tmp/evolvo-remote-glpmic
#  * [new branch]      main -> main
# To /tmp/evolvo-remote-XZXYwL
#  * [new branch]      main -> main
# Subtest: branchNameForIssue creates a deterministic branch slug
ok 35 - branchNameForIssue creates a deterministic branch slug
  ---
  duration_ms: 1.864737
  type: 'test'
  ...
# Subtest: buildAuthenticatedGitArgs injects a per-command auth header
ok 36 - buildAuthenticatedGitArgs injects a per-command auth header
  ---
  duration_ms: 0.548177
  type: 'test'
  ...
# Subtest: Workspace prepareBranch allows .env and .evolvo but blocks other dirty files
ok 37 - Workspace prepareBranch allows .env and .evolvo but blocks other dirty files
  ---
  duration_ms: 94.766407
  type: 'test'
  ...
# Subtest: Workspace prepareBranch checks out a deterministic issue branch
ok 38 - Workspace prepareBranch checks out a deterministic issue branch
  ---
  duration_ms: 125.289744
  type: 'test'
  ...
# Subtest: Workspace stages only touched files
ok 39 - Workspace stages only touched files
  ---
  duration_ms: 95.023841
  type: 'test'
  ...
# Subtest: Workspace clears touched files after a successful publish
ok 40 - Workspace clears touched files after a successful publish
  ---
  duration_ms: 170.273098
  type: 'test'
  ...
1..40
# tests 40
# suites 0
# pass 40
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 622.622671

$ pnpm check
> evolvo@0.2.0 check /home/paddy/Evolvo
> node --check src/index.js

```
Closes #29